### PR TITLE
Fix #109. Remove html5 attribution from the footer.

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -70,19 +70,6 @@ const Footer = () => (
       <LegalItem>
         <Link to="/imprint">{translations.imprintLinkText}</Link>
       </LegalItem>
-      <LegalItem>
-        {
-          //TODO: Remove this menu entry.
-        }
-        Design:&nbsp;&nbsp;
-        <a
-          href="https://html5up.net/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          html5 up
-        </a>
-      </LegalItem>
     </LegalBar>
   </footer>
 )


### PR DESCRIPTION
Fix #109. 
Remove html5 attribution from the footer.