### PR TITLE
Fix #119. Add a word break to the offerings headline.

### DIFF
--- a/src/components/Offerings/index.jsx
+++ b/src/components/Offerings/index.jsx
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import media from 'styled-media-query'
+import styles from '../helper.module.css'
+import cn from 'classnames'
 
 const Offering = styled.section`
   align-items: center;
@@ -107,7 +109,7 @@ const Offerings = ({ offerings }) => (
           <img alt="" src={item.image} />
         </OfferingImg>
         <OfferingText>
-          <h2>{item.headline}</h2>
+          <h2 className={cn(styles.breakWord)}>{item.headline}</h2>
           <p>{item.text}</p>
         </OfferingText>
       </Offering>

--- a/src/components/helper.module.css
+++ b/src/components/helper.module.css
@@ -1,0 +1,7 @@
+.breakWord {
+  word-break: break-all;
+
+  /* Non standard for WebKit */
+  word-break: break-word;
+  hyphens: auto;
+}


### PR DESCRIPTION
Fix #119.
The word 'Machbarkeitsstudien' was to long on mobile. Now the headlines break a word if its too long. 
I checked on my iPhone 5s and it works as expected.