### PR TITLE
Fix CMS schema: When no offerings exist, write empty list

### DIFF
--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -40,6 +40,7 @@ collections:
         format: "json"
         name: "faq"
         label: "FAQ"
+        identifier_field: "id"
         fields:
           - name: "id"
             label: "id"
@@ -67,6 +68,7 @@ collections:
         name: "home"
         label: "Landing Page"
         format: "json"
+        identifier_field: "id"
         fields:
           - name: "id"
             label: "Identifier"

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -39,8 +39,8 @@ collections:
       - file: "src/data/faqEntry/faq.json"
         format: "json"
         name: "faq"
-        label: 'FAQ'
-        fields:  
+        label: "FAQ"
+        fields:
           - name: "id"
             label: "id"
             description: "A name to identify this object within this collection. Should be unique within the collection."
@@ -112,6 +112,7 @@ collections:
               - name: "offerings"
                 label: "Offerings"
                 widget: "list"
+                default: []
                 fields:
                   - { name: "headline", widget: "string" }
                   - { name: "image", widget: "image", allow_multiple: false }


### PR DESCRIPTION
Current behaviour: The CMS omits the key 'offerings' entirely,
creating an object of incorrect type, if the user enters no offerings.
Desired behaviour: The CMS writes 'offerings' : []