### PR TITLE
WIP Fix #192. Add a language switcher to the navbar

### DIFF
--- a/src/components/Footer/component.tsx
+++ b/src/components/Footer/component.tsx
@@ -4,7 +4,7 @@ import styles from './Footer.module.scss'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEnvelope } from '@fortawesome/free-regular-svg-icons'
 import { faGithub } from '@fortawesome/free-brands-svg-icons'
-import { LinkProps } from '../Link'
+import { LinkProps, LocalizedLink } from '../Link'
 
 const LegalBar: FunctionComponent = ({ children }) => (
   <div
@@ -67,9 +67,9 @@ export const Footer: FunctionComponent<{
     <LegalBar>
       <LegalItem>{translations.copyrightText}</LegalItem>
       <LegalItem>
-        <InternalLink to="/de/imprint">
+        <LocalizedLink linkTag={InternalLink} to="/imprint">
           {translations.imprintLinkText}
-        </InternalLink>
+        </LocalizedLink>
       </LegalItem>
     </LegalBar>
   </div>

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,4 +1,8 @@
 import React, { FunctionComponent } from 'react'
+import { NavLink } from 'reactstrap'
+import * as R from 'ramda'
+import { useLocale, useLocation } from '../../utils/hooks'
+import { HistoryLocation } from '@reach/router'
 
 export interface LinkProps {
   className?: string
@@ -22,3 +26,17 @@ export const SafeExternalLink: FunctionComponent<LinkProps> = ({
     {children}
   </a>
 )
+
+export const LocalizedLink: FunctionComponent<{
+  to: string
+  className?: string
+  linkTag: any
+}> = ({ linkTag, to, children, className }) => {
+  const locale = useLocale()
+  const currentPrefix = locale === 'en' ? '/en' : '/de'
+  return (
+    <NavLink tag={linkTag} className={className} to={`${currentPrefix}${to}`}>
+      {children}
+    </NavLink>
+  )
+}

--- a/src/components/Link/index.tsx
+++ b/src/components/Link/index.tsx
@@ -1,8 +1,6 @@
 import React, { FunctionComponent } from 'react'
 import { NavLink } from 'reactstrap'
-import * as R from 'ramda'
-import { useLocale, useLocation } from '../../utils/hooks'
-import { HistoryLocation } from '@reach/router'
+import { useLocale } from '../../utils/hooks'
 
 export interface LinkProps {
   className?: string

--- a/src/components/Navbar/MenuEntries.tsx
+++ b/src/components/Navbar/MenuEntries.tsx
@@ -1,5 +1,9 @@
-import React from 'react'
+import React, { FunctionComponent } from 'react'
 import { NavItem, NavLink } from 'reactstrap'
+import * as R from 'ramda'
+import { useLocale, useLocation } from '../../utils/hooks'
+import { HistoryLocation } from '@reach/router'
+import { LocalizedLink } from '../Link'
 
 export const MenuEntries = ({
   linkTag,
@@ -16,10 +20,30 @@ export const MenuEntries = ({
         </NavLink>
       </NavItem>,
       <NavItem key="faq" className={showFAQ ? '' : 'd-none'}>
-        <NavLink to="/de/faq" tag={linkTag}>
+        <LocalizedLink to="/faq" linkTag={linkTag}>
           FAQ
-        </NavLink>
+        </LocalizedLink>
+      </NavItem>,
+      <NavItem key="languageSwitcher">
+        <LanguageSwitcher linkTag={linkTag} />
       </NavItem>,
     ]}
   </>
 )
+
+const LanguageSwitcher: FunctionComponent<{ linkTag: any }> = ({ linkTag }) => {
+  const locale = useLocale()
+  const { location } = useLocation()
+  const toPrefix = locale === 'en' ? '/de' : '/en'
+  const linkText = locale === 'en' ? 'DE' : 'EN'
+  const currentPrefix = locale === 'en' ? '/en' : '/de'
+  const to = R.pipe<HistoryLocation, string, string>(
+    R.prop('pathname'),
+    R.replace(currentPrefix, toPrefix),
+  )(location)
+  return (
+    <NavLink to={to} tag={linkTag}>
+      {linkText}
+    </NavLink>
+  )
+}

--- a/src/utils/hooks.tsx
+++ b/src/utils/hooks.tsx
@@ -37,7 +37,6 @@ export const useLocation = () => {
     location: globalHistory.location,
     navigate: globalHistory.navigate,
   }
-
   const [state, setState] = useState(initialState)
   useEffect(() => {
     const removeListener = globalHistory.listen(params => {

--- a/src/utils/hooks.tsx
+++ b/src/utils/hooks.tsx
@@ -1,5 +1,11 @@
-import React, { useContext, FunctionComponent, useState } from 'react'
+import React, {
+  useContext,
+  FunctionComponent,
+  useState,
+  useEffect,
+} from 'react'
 import { Locale } from '../data/i18n'
+import { globalHistory } from '@reach/router'
 
 type NavbarState = [boolean, (newValue: boolean) => void]
 
@@ -25,3 +31,24 @@ export const LocaleProvider = LocaleContext.Provider
 
 export const useNavbarState = () => useContext(NavbarContext)
 export const useLocale = () => useContext(LocaleContext)
+
+export const useLocation = () => {
+  const initialState = {
+    location: globalHistory.location,
+    navigate: globalHistory.navigate,
+  }
+
+  const [state, setState] = useState(initialState)
+  useEffect(() => {
+    const removeListener = globalHistory.listen(params => {
+      const { location } = params
+      const newState = Object.assign({}, initialState, { location })
+      setState(newState)
+    })
+    return () => {
+      removeListener()
+    }
+  }, [initialState])
+
+  return state
+}


### PR DESCRIPTION
Fix #192.

A user can now switch between the german and english version of the page via a button in the navbar.

![Selection_148](https://user-images.githubusercontent.com/43745180/68940427-609a2580-07a3-11ea-8a55-8e6dae8a3aa9.png)

:exclamation:  This feature should only be enabled once we are sure that the content for **both** language versions of the page is correct.