### PR TITLE
Refactor to support translation collections of primitive types

### DIFF
--- a/src/cms/preview-templates/FAQPreview.tsx
+++ b/src/cms/preview-templates/FAQPreview.tsx
@@ -1,20 +1,17 @@
 import React, { FunctionComponent } from 'react'
 import '../../scss/main.scss'
 import { PreviewProps, getJSON } from './helpers'
-import {
-  TranslationCollection,
-  extractSingleTranslation,
-} from '../../data/i18n'
-import { FAQPage } from '../../data/faqEntry'
+import { filterByLocale } from '../../data/i18n'
+import { FAQPage, FAQPageOnDisk } from '../../data/faqEntry'
 import { createPreview } from './Preview'
 import { FAQComponent } from '../../components/FAQ/component'
 
-const Preview = createPreview<TranslationCollection<FAQPage>, FAQPage>()
+const Preview = createPreview<FAQPageOnDisk, FAQPage>()
 
 export const FAQPreview: FunctionComponent<PreviewProps> = ({ entry }) => (
   <Preview
     Component={FAQComponent}
     data={getJSON(entry)}
-    translator={extractSingleTranslation}
+    translator={filterByLocale}
   />
 )

--- a/src/data/faqEntry/faq.json
+++ b/src/data/faqEntry/faq.json
@@ -1,19 +1,22 @@
 {
     "id": "FAQPage",
+    "faqEntries": [],
     "translations": [
         {
             "locale": "en",
-            "headline": "FAQ",
-            "subheadline": "Things you want to know",
-            "metaTitle": "faqPage",
-            "faqEntries": []
+            "value": {
+                "headline": "FAQ",
+                "subheadline": "Things you want to know",
+                "metaTitle": "faqPage"
+            }
         },
         {
             "locale": "de",
-            "headline": "FAQ",
-            "subheadline": "Alles was Sie wissen müssen",
-            "metaTitle": "faqPage",
-            "faqEntries": []
+            "value" : {
+               "headline": "FAQ",
+                "subheadline": "Alles was Sie wissen müssen",
+                "metaTitle": "faqPage"
+            }
         }
     ]
 }

--- a/src/data/faqEntry/index.tsx
+++ b/src/data/faqEntry/index.tsx
@@ -1,9 +1,5 @@
 import * as R from 'ramda'
-import {
-  Locale,
-  extractSingleTranslation,
-  TranslationCollection,
-} from '../i18n'
+import { Locale, TranslationCollection, filterByLocale } from '../i18n'
 import { useLocale } from '../../utils/hooks'
 import data from './faq.json'
 
@@ -14,15 +10,22 @@ export interface FAQPage {
   faqEntries: FAQEntry[]
 }
 
-const faq: TranslationCollection<FAQPage> = data
+export type FAQPageOnDisk = {
+  faqEntries: TranslationCollection<FAQEntry>[]
+} & TranslationCollection<{
+  headline: string
+  subheadline: string
+  metaTitle: string
+}>
+
+const faq: FAQPageOnDisk = data
 
 export interface FAQEntry {
   question: string
   answer: string
 }
 
-const getFAQPage = (locale: Locale): FAQPage =>
-  extractSingleTranslation<FAQPage>(locale)(faq)
+const getFAQPage = (locale: Locale): FAQPage => filterByLocale(locale)(faq)
 
 export const useFAQPage: () => FAQPage = R.pipe(useLocale, getFAQPage)
 

--- a/src/data/footer/footer.json
+++ b/src/data/footer/footer.json
@@ -2,17 +2,21 @@
   "translations": [
     {
       "locale": "de",
-      "imprintLinkText": "Impressum",
-      "githubLinkURL": "https://github.com/hardforkio",
-      "contactEmail": "contact@hardfork.io",
-      "copyrightText" : "© 2017-2019 Hardfork GmbH"
+      "value" : {
+         "imprintLinkText": "Impressum",
+         "githubLinkURL": "https://github.com/hardforkio",
+         "contactEmail": "contact@hardfork.io",
+         "copyrightText" : "© 2017-2019 Hardfork GmbH"
+      }
     },
     {
       "locale": "en",
-      "imprintLinkText": "Imprint",
-      "githubLinkURL": "https://github.com/hardforkio",
-      "contactEmail": "contact@hardfork.io",
-      "copyrightText" : "© 2017-2019 Hardfork GmbH"
+      "value" : {
+         "imprintLinkText": "Imprint",
+         "githubLinkURL": "https://github.com/hardforkio",
+         "contactEmail": "contact@hardfork.io",
+         "copyrightText" : "© 2017-2019 Hardfork GmbH"
+      }
     }
   ]
 }

--- a/src/data/home/home.json
+++ b/src/data/home/home.json
@@ -6,15 +6,19 @@
       "translations": [
         {
           "locale": "de",
-          "headline": "Software",
-          "image": "/img/pic01.jpg",
-          "text": "Wir entwickeln für Sie Software-Applikationen nach Ihren Vorstellungen. Unser Team besitzt alle dafür notwendigen Kompetenzen vom Frontend mit komplexem Application State Management über Client zu Server Kommunikation und Backend-Entwicklung bis zum skalierbaren und sicheren Betrieb in der Cloud. Mit Hardfork bekommen Sie Ihren gesamten Stack aus einer Hand.\n\nWir nutzen unter anderem die Technologien bzw. Libraries React, Redux, TypeScript, Apollo, GraphQL, Gatsby, Netlify, SQL (auch serverless) und AWS serverless."
+          "value" : {
+            "headline": "Software",
+            "image": "/img/pic01.jpg",
+             "text": "Wir entwickeln für Sie Software-Applikationen nach Ihren Vorstellungen. Unser Team besitzt alle dafür notwendigen Kompetenzen vom Frontend mit komplexem Application State Management über Client zu Server Kommunikation und Backend-Entwicklung bis zum skalierbaren und sicheren Betrieb in der Cloud. Mit Hardfork bekommen Sie Ihren gesamten Stack aus einer Hand.\n\nWir nutzen unter anderem die Technologien bzw. Libraries React, Redux, TypeScript, Apollo, GraphQL, Gatsby, Netlify, SQL (auch serverless) und AWS serverless."
+          }
         },
         {
           "locale": "en",
-          "headline": "Software",
-          "image": "/img/codeonscreen.jpg",
-          "text": "We build software and web applications according to your needs. Our team  is proficient in all required technologies be it complex frontend application state management, client to server communication, backend development or reliable and scaling deployment and delivery from the cloud. With Hardfork you get your whole stack from one supplier.\n\nWe use the technologies and libraries that provide the most value for your project. Usually these include React, Redux, TypeScript, Apollo, GraphQL, Gatsby, Netlify, SQL (auch serverless) and / or AWS serverless."
+          "value" : {
+            "headline": "Software",
+            "image": "/img/codeonscreen.jpg",
+            "text": "We build software and web applications according to your needs. Our team  is proficient in all required technologies be it complex frontend application state management, client to server communication, backend development or reliable and scaling deployment and delivery from the cloud. With Hardfork you get your whole stack from one supplier.\n\nWe use the technologies and libraries that provide the most value for your project. Usually these include React, Redux, TypeScript, Apollo, GraphQL, Gatsby, Netlify, SQL (auch serverless) and / or AWS serverless."
+          }
         }
       ]
     },
@@ -23,15 +27,19 @@
       "translations": [
         {
           "locale": "de",
-          "headline": "Company Value",
-          "image": "/img/pic02.jpg",
-          "text": "Wir verstehen uns nicht als reiner Technologiedienstleister sondern als Partner für das Erreichen von Unternehmenszielen. Durch unseren Hintergrund im Startup-Ökosystem von Berlin wissen wir, dass Software zuallererst Wert für den Kunden generieren muss. Wir berücksichtigen dies sowohl bei den grundlegenden Architekturentscheidungen als auch bei der täglichen Auswahl von Implementierungsdetails, die sich in der Software-Entwicklung ergeben."
+          "value": {
+            "headline": "Company Value",
+            "image": "/img/pic02.jpg",
+            "text": "Wir verstehen uns nicht als reiner Technologiedienstleister sondern als Partner für das Erreichen von Unternehmenszielen. Durch unseren Hintergrund im Startup-Ökosystem von Berlin wissen wir, dass Software zuallererst Wert für den Kunden generieren muss. Wir berücksichtigen dies sowohl bei den grundlegenden Architekturentscheidungen als auch bei der täglichen Auswahl von Implementierungsdetails, die sich in der Software-Entwicklung ergeben."
+          }
         },
         {
           "locale": "en",
-          "headline": "Company value",
-          "image": "/img/pic01.jpg",
-          "text": "We do not see ourselves as a purely technical supplier but as a partner to help you achieve your company goals. With our background in the Berlin start up ecosystem we know that software firstly needs to generate value for our client's business. We consider this not only when choosing the right architecture and set up for your project but also in all small decisions the daily software development requires."
+          "value" : {
+            "headline": "Company value",
+            "image": "/img/pic01.jpg",
+            "text": "We do not see ourselves as a purely technical supplier but as a partner to help you achieve your company goals. With our background in the Berlin start up ecosystem we know that software firstly needs to generate value for our client's business. We consider this not only when choosing the right architecture and set up for your project but also in all small decisions the daily software development requires."
+          }
         }
       ]
     },
@@ -40,15 +48,19 @@
       "translations": [
         {
           "locale": "de",
-          "headline": "Qualität und Transparenz",
-          "image": "/img/pic03.jpg",
-          "text": "Bei Hardfork arbeiten ausschließlich hoch ausgebildete Software-Entwickler in Festanstellung. Unsere Arbeit ist für den Kunden zu jeder Zeit einsehbar, die von uns entwickelte Software steht vom ersten Tag an für den Kunden zum Testen zur Verfügung. Wir arbeiten grundsätzlich mit automatisierten Tests, Continous Integration und Deployment und veröffentlichen neuen Code nur im Vier-Augen-Prinzip."
+          "value" : {
+            "headline": "Qualität und Transparenz",
+            "image": "/img/pic03.jpg",
+            "text": "Bei Hardfork arbeiten ausschließlich hoch ausgebildete Software-Entwickler in Festanstellung. Unsere Arbeit ist für den Kunden zu jeder Zeit einsehbar, die von uns entwickelte Software steht vom ersten Tag an für den Kunden zum Testen zur Verfügung. Wir arbeiten grundsätzlich mit automatisierten Tests, Continous Integration und Deployment und veröffentlichen neuen Code nur im Vier-Augen-Prinzip."
+          }
         },
         {
           "locale": "en",
-          "headline": "Quality and transparency",
-          "image": "/img/pic02.jpg",
-          "text": "At Hardfork we only work with highly qualified engineers in full time employment. Our work can be reviewed by the client at all times and the software built by us can be used and experienced from day one. We always work with automated tests, continous integration and deployment and ship new code only after careful review in the team."
+          "value": {
+            "headline": "Quality and transparency",
+            "image": "/img/pic02.jpg",
+            "text": "At Hardfork we only work with highly qualified engineers in full time employment. Our work can be reviewed by the client at all times and the software built by us can be used and experienced from day one. We always work with automated tests, continous integration and deployment and ship new code only after careful review in the team."
+          }
         }
       ]
     }
@@ -56,28 +68,33 @@
   "contactEmail": "mailto:contact@hardfork.io",
   "translations": [
     {
-      "heading": "Ihr Partner für anspruchsvolle Softwareprojekte",
-      "emailButton": "E-Mail senden",
-      "metaTitle": "Hardfork GmbH - Software Entwicklung und Business Development",
-      "contactHeadline": "Kontaktanfrage",
-      "metaDescription": "Wir entwickeln Software nach Ihren Wünschen in Berlin",
-      "title": "Hardfork",
       "locale": "de",
-      "moreLinkText": "Mehr",
-      "contactDescription": "Bitte schreiben Sie uns eine Email und wir melden uns zurück.",
-      "contactButtonText": "Kontakt"
+      "value": {
+        "heading": "Ihr Partner für anspruchsvolle Softwareprojekte",
+        "emailButton": "E-Mail senden",
+        "metaTitle": "Hardfork GmbH - Software Entwicklung und Business Development",
+        "contactHeadline": "Kontaktanfrage",
+        "metaDescription": "Wir entwickeln Software nach Ihren Wünschen in Berlin",
+        "title": "Hardfork",
+      
+        "moreLinkText": "Mehr",
+        "contactDescription": "Bitte schreiben Sie uns eine Email und wir melden uns zurück.",
+        "contactButtonText": "Kontakt"
+      }
     },
     {
-      "heading": "Your partner for challenging software projects",
-      "emailButton": "Send E-Mail",
-      "metaTitle": "Hardfork GmbH - Software development and business services",
-      "contactHeadline": "Send e-mail",
-      "metaDescription": "We develop software according to your needs in Berlin, Germany",
-      "title": "Hardfork",
       "locale": "en",
-      "moreLinkText": "More",
-      "contactDescription": "Please send us an e-mail and we will be in touch shortly!",
-      "contactButtonText": "Contact"
+      "value" : {
+        "heading": "Your partner for challenging software projects",
+        "emailButton": "Send E-Mail",
+        "metaTitle": "Hardfork GmbH - Software development and business services",
+        "contactHeadline": "Send e-mail",
+        "metaDescription": "We develop software according to your needs in Berlin, Germany",
+        "title": "Hardfork",
+        "moreLinkText": "More",
+        "contactDescription": "Please send us an e-mail and we will be in touch shortly!",
+        "contactButtonText": "Contact"
+      }
     }
   ]
 }

--- a/src/data/i18n.test.tsx
+++ b/src/data/i18n.test.tsx
@@ -13,8 +13,8 @@ test('extractSingleTranslation selects the desired language version', test => {
   type Word = { word: string }
   const PET: TranslationCollection<Word> = {
     translations: [
-      { locale: EN, word: 'dog' },
-      { locale: DE, word: 'hund' },
+      { locale: EN, value: { word: 'dog' } },
+      { locale: DE, value: { word: 'hund' } },
     ],
   }
 
@@ -26,7 +26,7 @@ test('extractSingleTranslation selects the desired language version', test => {
 test('extractSingleTranslation returns some language version, when user asks for a language that does not exist', test => {
   type Word = { word: string }
   const data: TranslationCollection<Word> = {
-    translations: [{ locale: DE, word: 'hund' }],
+    translations: [{ locale: DE, value: { word: 'hund' } }],
   }
 
   test.plan(1)
@@ -50,15 +50,15 @@ test('filterByLocal example: petstore', test => {
     {
       id: 'dog',
       translations: [
-        { locale: EN, name: 'dog' },
-        { locale: DE, name: 'Hund' },
+        { locale: EN, value: { name: 'dog' } },
+        { locale: DE, value: { name: 'Hund' } },
       ],
     },
     {
       id: 'cat',
       translations: [
-        { locale: EN, name: 'cat' },
-        { locale: DE, name: 'Katze' },
+        { locale: EN, value: { name: 'cat' } },
+        { locale: DE, value: { name: 'Katze' } },
       ],
     },
   ]
@@ -66,8 +66,8 @@ test('filterByLocal example: petstore', test => {
     {
       id: 'dog bone',
       translations: [
-        { locale: EN, name: 'dog bone' },
-        { locale: DE, name: 'Hundeknochen' },
+        { locale: EN, value: { name: 'dog bone' } },
+        { locale: DE, value: { name: 'Hundeknochen' } },
       ],
     },
   ]
@@ -79,13 +79,17 @@ test('filterByLocal example: petstore', test => {
     translations: [
       {
         locale: EN,
-        description: 'A lot of pets and some toys',
-        pets,
+        value: {
+          description: 'A lot of pets and some toys',
+          pets,
+        },
       },
       {
         locale: DE,
-        description: 'Viele Tiere und deren Spielzeuge',
-        pets: [pets[0]],
+        value: {
+          description: 'Viele Tiere und deren Spielzeuge',
+          pets: [pets[0]],
+        },
       },
     ],
   }

--- a/src/data/i18n.test.tsx
+++ b/src/data/i18n.test.tsx
@@ -2,7 +2,6 @@ import test from 'tape'
 import {
   Locale,
   TranslationCollection,
-  getTranslations,
   filterByLocale,
   extractSingleTranslation,
 } from './i18n'
@@ -32,22 +31,6 @@ test('extractSingleTranslation returns some language version, when user asks for
 
   test.plan(1)
   test.deepEqual(extractSingleTranslation(EN)(data), { word: 'hund' })
-})
-
-test('getTranslations gets a list of language versions', test => {
-  type Word = { word: string }
-  const PET: TranslationCollection<Word> = {
-    translations: [
-      { locale: EN, word: 'dog' },
-      { locale: DE, word: 'hund' },
-    ],
-  }
-
-  test.plan(1)
-  test.deepEqual(getTranslations(PET), [
-    { locale: EN, word: 'dog' },
-    { locale: DE, word: 'hund' },
-  ])
 })
 
 test('filterByLocal on basic objects', test => {

--- a/src/data/i18n.tsx
+++ b/src/data/i18n.tsx
@@ -23,10 +23,6 @@ export const extractSingleTranslation: <T = any, S = {}>(
     R.omit(['translations']),
   ])
 
-export const getTranslations: <T = any>(
-  data: TranslationCollection<T>,
-) => WithLocale<T>[] = R.prop('translations')
-
 export const filterByLocale: (locale: Locale) => (currentNode: any) => any = (
   locale: Locale,
 ) =>

--- a/src/data/i18n.tsx
+++ b/src/data/i18n.tsx
@@ -3,7 +3,7 @@ import { findDefaultingToHead } from '../utils/helpers'
 export const LOCALES = ['en', 'de'] as const
 export type Locale = typeof LOCALES[number]
 
-type WithLocale<T> = T & { locale: string }
+type WithLocale<T> = { value: T; locale: string }
 
 export interface TranslationCollection<T> {
   translations: WithLocale<T>[]
@@ -18,7 +18,7 @@ export const extractSingleTranslation: <T = any, S = {}>(
     R.pipe(
       R.prop('translations'),
       findDefaultingToHead(R.propEq('locale', locale)),
-      R.omit(['locale']) as (content: WithLocale<T>) => T,
+      R.prop('value'),
     ),
     R.omit(['translations']),
   ])

--- a/src/data/imprint/imprint.json
+++ b/src/data/imprint/imprint.json
@@ -3,17 +3,21 @@
   "translations": [
     {
       "locale": "en",
-      "headline": "Imprint",
-      "subHeadline": "Hardfork GmbH Berlin",
-      "metaTitle": "Imprint Hardfork GmbH",
-      "content": "###### Information pursuant to § 5 TMG\n\nHardfork GmbH\\\nMühlenstraße 8a\\\n14167 Berlin\n\nRepresented by: CEO Levin Keller\n\nRegistered at Amtsgericht Charlottenburg as HRB 162146 B\n\n###### Contact\n\n- Phone: +4915156041082\n- E-mail: contact@hardfork.io\n\n###### Tax\n\nVAT ID: DE297380065\n\n###### Responsible for content pursuant to § 55 Abs. 2 RStV\n\nLevin Keller\\\nHardfork GmbH\\\nMühlenstraße 8a\\\n14167 Berlin"
+      "value": {
+        "headline": "Imprint",
+        "subHeadline": "Hardfork GmbH Berlin",
+        "metaTitle": "Imprint Hardfork GmbH",
+        "content": "###### Information pursuant to § 5 TMG\n\nHardfork GmbH\\\nMühlenstraße 8a\\\n14167 Berlin\n\nRepresented by: CEO Levin Keller\n\nRegistered at Amtsgericht Charlottenburg as HRB 162146 B\n\n###### Contact\n\n- Phone: +4915156041082\n- E-mail: contact@hardfork.io\n\n###### Tax\n\nVAT ID: DE297380065\n\n###### Responsible for content pursuant to § 55 Abs. 2 RStV\n\nLevin Keller\\\nHardfork GmbH\\\nMühlenstraße 8a\\\n14167 Berlin"
+      }
     },
     {
       "locale": "de",
-      "headline": "Impressum",
-      "subHeadline": "Hardfork GmbH Berlin",
-      "metaTitle": "Impressum Hardform GmbH",
-      "content": "###### Angaben gemäß § 5 TMG\n\nHardfork GmbH\\\nMühlenstraße 8a\\\n14167 Berlin\n\nVertreten durch: Geschäftsführer Levin Keller\n\nRegistriert am Amtsgericht Charlottenburg unter HRB 162146 B\n\n###### Kontakt\n\n- Telefon: +4915156041082\n- E-mail: contact@hardfork.io\n\n###### Umsatzsteuer\n\nUSt-ID: DE297380065\n\n###### Verantwortlich für Inhalte nach § 55 Abs. 2 RStV\n\nLevin Keller\\\nHardfork GmbH\\\nMühlenstraße 8a\\\n14167 Berlin"
+      "value": {
+        "headline": "Impressum",
+        "subHeadline": "Hardfork GmbH Berlin",
+        "metaTitle": "Impressum Hardform GmbH",
+        "content": "###### Angaben gemäß § 5 TMG\n\nHardfork GmbH\\\nMühlenstraße 8a\\\n14167 Berlin\n\nVertreten durch: Geschäftsführer Levin Keller\n\nRegistriert am Amtsgericht Charlottenburg unter HRB 162146 B\n\n###### Kontakt\n\n- Telefon: +4915156041082\n- E-mail: contact@hardfork.io\n\n###### Umsatzsteuer\n\nUSt-ID: DE297380065\n\n###### Verantwortlich für Inhalte nach § 55 Abs. 2 RStV\n\nLevin Keller\\\nHardfork GmbH\\\nMühlenstraße 8a\\\n14167 Berlin"
+      }
     }
   ]
 }

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -37,11 +37,16 @@ collections:
             label: "translations"
             widget: "list"
             fields:
-              - { name: "locale", widget: "select", <<: *locales }
-              - { name: "headline", widget: "string" }
-              - { name: "subHeadline", widget: "string" }
-              - { name: "metaTitle", widget: "string" }
-              - { name: "content", widget: "markdown" }
+              - name: "locale"
+                widget: "select"
+                <<: *locales
+              - name: "value"
+                widget: "object"
+                fields:
+                  - { name: "headline", widget: "string" }
+                  - { name: "subHeadline", widget: "string" }
+                  - { name: "metaTitle", widget: "string" }
+                  - { name: "content", widget: "markdown" }
 
   - name: "faqPage"
     label: "FaqPage"
@@ -60,16 +65,33 @@ collections:
             label: "translations"
             widget: "list"
             fields:
-              - { name: "locale", widget: "select", <<: *locales }
-              - { name: "headline", widget: "string" }
-              - { name: "subheadline", widget: "string" }
-              - { name: "metaTitle", widget: "string" }
-              - name: "faqEntries"
-                widget: "list"
-                default: []
+              - name: "locale"
+                widget: "select"
+                <<: *locales
+              - name: "value"
+                widget: "object"
                 fields:
-                  - { name: "question", widget: "string" }
-                  - { name: "answer", widget: "markdown" }
+                  - { name: "headline", widget: "string" }
+                  - { name: "subheadline", widget: "string" }
+                  - { name: "metaTitle", widget: "string" }
+          - name: "faqEntries"
+            widget: "list"
+            default: []
+            identfier_field: "id"
+            fields:
+              - name: "id"
+                widget: "string"
+              - name: "translations"
+                widget: "list"
+                fields:
+                  - name: "locale"
+                    widget: "select"
+                    <<: *locales
+                  - name: "value"
+                    widget: "object"
+                    fields:
+                      - { name: "question", widget: "string" }
+                      - { name: "answer", widget: "markdown" }
 
   - name: "home"
     label: "Landing Page"
@@ -100,10 +122,19 @@ collections:
                 label: "translations"
                 widget: "list"
                 fields:
-                  - { name: "locale", widget: "select", <<: *locales }
-                  - { name: "headline", widget: "string" }
-                  - { name: "image", widget: "image", allow_multiple: false }
-                  - { name: "text", widget: "text" }
+                  - name: "locale"
+                    widget: "select"
+                    <<: *locales
+                  - name: "value"
+                    widget: "object"
+                    fields:
+                      - { name: "headline", widget: "string" }
+                      - {
+                          name: "image",
+                          widget: "image",
+                          allow_multiple: false,
+                        }
+                      - { name: "text", widget: "text" }
 
           - name: "contactEmail"
             widget: "string"
@@ -116,35 +147,38 @@ collections:
                 widget: "select"
                 <<: *locales
 
-              - name: "title"
-                widget: "string"
-                label: "Page title"
-                description: "Title shown on top of page. Not an ID."
+              - name: "value"
+                widget: "object"
+                fields:
+                  - name: "title"
+                    widget: "string"
+                    label: "Page title"
+                    description: "Title shown on top of page. Not an ID."
 
-              - name: "heading"
-                widget: "string"
+                  - name: "heading"
+                    widget: "string"
 
-              - name: "contactHeadline"
-                widget: "string"
-                description: "Contact Section Headline"
+                  - name: "contactHeadline"
+                    widget: "string"
+                    description: "Contact Section Headline"
 
-              - name: "contactDescription"
-                widget: "string"
+                  - name: "contactDescription"
+                    widget: "string"
 
-              - name: "contactButtonText"
-                widget: "string"
+                  - name: "contactButtonText"
+                    widget: "string"
 
-              - name: "moreLinkText"
-                widget: "string"
+                  - name: "moreLinkText"
+                    widget: "string"
 
-              - name: "emailButton"
-                widget: "string"
+                  - name: "emailButton"
+                    widget: "string"
 
-              - name: "metaTitle"
-                widget: "string"
+                  - name: "metaTitle"
+                    widget: "string"
 
-              - name: "metaDescription"
-                widget: "string"
+                  - name: "metaDescription"
+                    widget: "string"
 
   - name: "footer"
     label: "Footer"
@@ -170,14 +204,17 @@ collections:
                 widget: "select"
                 <<: *locales
 
-              - name: "imprintLinkText"
-                widget: "string"
+              - name: "value"
+                widget: "object"
+                fields:
+                  - name: "imprintLinkText"
+                    widget: "string"
 
-              - name: "githubLinkURL"
-                widget: "string"
+                  - name: "githubLinkURL"
+                    widget: "string"
 
-              - name: "contactEmail"
-                widget: "string"
+                  - name: "contactEmail"
+                    widget: "string"
 
-              - name: "copyrightText"
-                widget: "string"
+                  - name: "copyrightText"
+                    widget: "string"


### PR DESCRIPTION
Refactored the TranslationCollection type to allow `TranslationCollection<string>`, `TranslationCollection<number>`, etc.

Why? 
 - This will help build the i18nstring widget
 - This will allow to localize leaves of the schema. Leaves are usually primitive types

Also: resolve #220