### PR TITLE
Proposal: Add cms json data to graphQL 

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -58,9 +58,16 @@ module.exports = {
         },
       },
     },
+    {
+      resolve: 'gatsby-source-filesystem',
+      options: {
+        path: `${__dirname}/src/data/navbar/`,
+      },
+    },
     'gatsby-plugin-sharp',
     'gatsby-transformer-sharp',
-    `gatsby-plugin-sitemap`,
+    'gatsby-transformer-json',
+    'gatsby-plugin-sitemap',
     'gatsby-plugin-robots-txt',
     {
       resolve: `gatsby-plugin-manifest`,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "gatsby-plugin-sharp": "^2.2.32",
     "gatsby-plugin-sitemap": "^2.2.19",
     "gatsby-source-filesystem": "^2.1.33",
+    "gatsby-transformer-json": "^2.4.11",
     "gatsby-transformer-sharp": "^2.3.0",
     "glob": "^7.1.6",
     "i18next": "^19.0.2",

--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -8,15 +8,11 @@ import { getHome } from '../data/home'
 import { HomeData } from '../data/home/types'
 import { getImprint } from '../data/imprint'
 import { Imprint } from '../data/imprint/types'
-import { getNavbar } from '../data/navbar'
-import { Navbar } from '../data/navbar/types'
 import { getProjects } from '../data/project'
 import { ProjectData } from '../data/project/types'
 import { useLocale } from '../utils/hooks'
 
 export const useProjects: () => ProjectData[] = R.pipe(useLocale, getProjects)
-
-export const useNavbar: () => Navbar = R.pipe(useLocale, getNavbar)
 
 export const useImprint: () => Imprint = R.pipe(useLocale, getImprint)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10220,6 +10220,14 @@ gatsby-telemetry@^1.3.29:
     node-fetch "2.6.0"
     uuid "3.4.0"
 
+gatsby-transformer-json@^2.4.11:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/gatsby-transformer-json/-/gatsby-transformer-json-2.4.11.tgz#aeae29b0fa546a4443582499adfe3c9a04fd7295"
+  integrity sha512-eOZHf/azsIqz7pqYyPBdwk2jqiviaFZwuRQWYxfRpvyohPdSMAgrKgLreJaORfjt0+i3saRBXmkIFDq4Q0iJTA==
+  dependencies:
+    "@babel/runtime" "^7.10.3"
+    bluebird "^3.7.2"
+
 gatsby-transformer-sharp@^2.3.0:
   version "2.5.13"
   resolved "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.5.13.tgz#f323072d885c0fae54a55cb105f543d7c08d3a14"


### PR DESCRIPTION
This is a small proposal for adding the content data to graphQL and utilise the `useStaticQuery` hook in the component. This way we can get rid of all the content hooks (e.g. `useNavbar`) and importing the `.json` files. 
![Selection_207](https://user-images.githubusercontent.com/43745180/92876741-bd3d8f80-f40a-11ea-912a-c9d3b5d59dd7.png)

Maybe I forgot something why this approach is not feasible but I came across this solution on my own project.